### PR TITLE
Workaround for Chromecast DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,21 @@ as well as which DNS server it will forward requests to.
 
 The Netflix apps for Chromecast and Android have started **ignoring the DNS
 servers announced over DHCP and will send queries directly to 8.8.8.8 and/or
-8.8.4.4**.  If you are running this proxy on your network's default gateway,
+8.8.4.4**. If you are running this proxy on your network's default gateway,
 simply configure the LAN-facing interface with these addresses to force all
-queries to them to be handled by the proxy.  If you are running the DNS proxy
+queries to them to be handled by the proxy. If you are running the DNS proxy
 on another box, you will have to configure your router to NAT DNS requests to
 these addresses to that other box.
+
+Alternatively, if you block the Google Public DNS servers at the router level
+this will force a Chromecast device to fallback to the DNS servers pushed via DHCP.
+
+An example of achieving this with `iptables`:
+
+```
+iptables -I FORWARD --destination 8.8.8.8 -j REJECT
+iptables -I FORWARD --destination 8.8.4.4 -j REJECT
+```
 
 Note that if you are using dnsmasq and its built-in DHCP server, and you
 reconfigure it to listen on a port other than 53 for DNS, it will stop


### PR DESCRIPTION
Rather than having to mess around with DNAT and intercept DNS requests, you can simply block the Google DNS servers of `8.8.8.8` and `8.8.4.4` and this will make a Chromecast device use the DNS servers configured via DHCP. I assume Chromecast devices have a check to see if it can reach Google's public DNS addresses, and if it can't it then uses DHCP.

You would need to have full control of the firewall at router level to do it, but this is pretty simple to do with an OpenWRT, DD-WRT or similar firmware.
