### PR TITLE
fix blackhole default value

### DIFF
--- a/server.py
+++ b/server.py
@@ -32,7 +32,7 @@ OPTIONS = {
     # interface if you want it preserved on reboots.
     #
     # # ip route add unreachable 0100::/64
-    'blackhole': False,  # b'100::1',
+    'blackhole': None,  # b'100::1',
 }
 
 from twisted.internet import reactor, defer


### PR DESCRIPTION
Default blackhole option should be None. False does not work.
