### PR TITLE
Add "nflxext" domain

### DIFF
--- a/server.py
+++ b/server.py
@@ -42,7 +42,7 @@ class BlockNetflixAAAAResolver(object):
     def __shouldBlock(self, query):
         penultimateDomainPart = query.name.name.split('.')[-2]
 
-        return query.type == dns.AAAA and penultimateDomainPart in ('netflix', 'nflximg')
+        return query.type == dns.AAAA and penultimateDomainPart in ('netflix', 'nflximg', 'nflxext')
 
     def query(self, query, timeout=None):
         if self.__shouldBlock(query):


### PR DESCRIPTION
I was getting blocked by Netflix when using my SixXS tunnel. I noticed that the browser was connecting to "nflxext.com" which was not on the list of domains to block.

Streaming from Netflix works for me after adding "nflxext" to the list.
