### PR TITLE
Add docker instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.6
+
+# install dependencies
+RUN apk --no-cache add py-twisted py2-pip && \
+    pip2 install incremental constantly packaging
+
+# copy code
+COPY . /opt/netflix-no-ipv6-dns-proxy/
+
+# overwrite default config with docker default
+COPY config.py.docker /opt/netflix-no-ipv6-dns-proxy/config.py
+
+EXPOSE 53
+
+WORKDIR /opt/netflix-no-ipv6-dns-proxy/
+ENTRYPOINT ./server.py

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The only dependency is Twisted Names for Python.
 
 ## Configuration
 
-Open `server.py` and configure the `OPTIONS` dict according to the comments.
+Open `config.py` and configure the `OPTIONS` dict according to the comments.
 Here you will be able to configure which address and port this server binds to,
 as well as which DNS server it will forward requests to.
 
@@ -94,5 +94,9 @@ Alternatively without `docker-compose`:
 
 ```bash
 docker build -t dnsproxy .
-docker run -d dnsproxy
+docker run -d -p 53:53 -p 53:53/udp dnsproxy
 ```
+
+Configuration is copied from `config.py.docker` during build.
+Rebuild is required after changing it. Alternatively you might point a config to
+`/opt/netflix-no-ipv6-dns-proxy/config.py` using docker volumes.

--- a/README.md
+++ b/README.md
@@ -80,3 +80,19 @@ If you're using launchd (eg: macOS), install the launchd.plist and load the serv
 
     sudo cp com.github.cdhowie.netflix-no-ipv6-dns-proxy.plist /Library/LaunchDaemons
     sudo launchctl load -w /Library/LaunchDaemons/com.github.cdhowie.netflix-no-ipv6-dns-proxy.plist
+
+
+## Run using docker
+
+Clone this repository and run the following commands within the source directory:
+
+```bash
+docker-compose up -d
+```
+
+Alternatively without `docker-compose`:
+
+```bash
+docker build -t dnsproxy .
+docker run -d dnsproxy
+```

--- a/config.py
+++ b/config.py
@@ -1,0 +1,34 @@
+OPTIONS = {
+    # Port to bind to.
+    'listen-port': 53,
+
+    # Address to bind to.  '::' will bind IPv6; make sure bindv6only is 0 in
+    # your sysctl configuration for this binding to service IPv4 clients, too.
+    # ("cat /proc/sys/net/ipv6/bindv6only" to verify.)
+    'listen-address': '::',
+
+    # Here is where you configure what DNS server to proxy to.  You must
+    # specify exactly one of the following options; comment out the other.
+
+    # Specify one or more servers to proxy to.  Note that Twisted may not be
+    # happy if you use an IPv6 address.
+    # 'upstream-dns': [('127.0.0.1', 10053)],
+
+    # Specify a resolv.conf file from which to read upstream nameservers.  As
+    # noted above, if you have any upstream IPv6 servers, Twisted may not be
+    # happy about that.
+    #'resolv-conf': '/etc/resolv.conf',
+
+    # Set this to an IPv6 address and all blocked queries will return this
+    # address instead of an empty result set.  The Android Netflix client has
+    # (for me) started getting testy when AAAA queries return nothing.  Set
+    # this to an address in an unreachable route to resolve that issue.  I
+    # suggest b'100::1' as this is within the RFC6666-specified discard prefix.
+    #
+    # Run this command on your Linux router to add an unreachable route for the
+    # entire discard prefix (100::/64).  Add it to the "up" script for your lo
+    # interface if you want it preserved on reboots.
+    #
+    # # ip route add unreachable 0100::/64
+    'blackhole': None,  # b'100::1',
+}

--- a/config.py.docker
+++ b/config.py.docker
@@ -1,0 +1,34 @@
+OPTIONS = {
+    # Port to bind to.
+    'listen-port': 53,
+
+    # Address to bind to.  '::' will bind IPv6; make sure bindv6only is 0 in
+    # your sysctl configuration for this binding to service IPv4 clients, too.
+    # ("cat /proc/sys/net/ipv6/bindv6only" to verify.)
+    'listen-address': '::',
+
+    # Here is where you configure what DNS server to proxy to.  You must
+    # specify exactly one of the following options; comment out the other.
+
+    # Specify one or more servers to proxy to.  Note that Twisted may not be
+    # happy if you use an IPv6 address.
+    # 'upstream-dns': [('127.0.0.1', 10053)],
+
+    # Specify a resolv.conf file from which to read upstream nameservers.  As
+    # noted above, if you have any upstream IPv6 servers, Twisted may not be
+    # happy about that.
+    'resolv-conf': '/etc/resolv.conf',
+
+    # Set this to an IPv6 address and all blocked queries will return this
+    # address instead of an empty result set.  The Android Netflix client has
+    # (for me) started getting testy when AAAA queries return nothing.  Set
+    # this to an address in an unreachable route to resolve that issue.  I
+    # suggest b'100::1' as this is within the RFC6666-specified discard prefix.
+    #
+    # Run this command on your Linux router to add an unreachable route for the
+    # entire discard prefix (100::/64).  Add it to the "up" script for your lo
+    # interface if you want it preserved on reboots.
+    #
+    # # ip route add unreachable 0100::/64
+    'blackhole': None,  # b'100::1',
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+  dnsproxy:
+    build: .
+    ports:
+      - 53:53
+      - 53:53/udp

--- a/server.py
+++ b/server.py
@@ -1,39 +1,6 @@
 #!/usr/bin/env python
 
-OPTIONS = {
-    # Port to bind to.
-    'listen-port': 53,
-
-    # Address to bind to.  '::' will bind IPv6; make sure bindv6only is 0 in
-    # your sysctl configuration for this binding to service IPv4 clients, too.
-    # ("cat /proc/sys/net/ipv6/bindv6only" to verify.)
-    'listen-address': '::',
-
-    # Here is where you configure what DNS server to proxy to.  You must
-    # specify exactly one of the following options; comment out the other.
-
-    # Specify one or more servers to proxy to.  Note that Twisted may not be
-    # happy if you use an IPv6 address.
-    # 'upstream-dns': [('127.0.0.1', 10053)],
-
-    # Specify a resolv.conf file from which to read upstream nameservers.  As
-    # noted above, if you have any upstream IPv6 servers, Twisted may not be
-    # happy about that.
-    # 'resolv-conf': '/etc/resolv.conf',
-
-    # Set this to an IPv6 address and all blocked queries will return this
-    # address instead of an empty result set.  The Android Netflix client has
-    # (for me) started getting testy when AAAA queries return nothing.  Set
-    # this to an address in an unreachable route to resolve that issue.  I
-    # suggest b'100::1' as this is within the RFC6666-specified discard prefix.
-    #
-    # Run this command on your Linux router to add an unreachable route for the
-    # entire discard prefix (100::/64).  Add it to the "up" script for your lo
-    # interface if you want it preserved on reboots.
-    #
-    # # ip route add unreachable 0100::/64
-    'blackhole': None,  # b'100::1',
-}
+from config import OPTIONS
 
 from twisted.internet import reactor, defer
 from twisted.names import client, dns, error, server


### PR DESCRIPTION
I created a basic docker configuration using alpine linux as base.

To make this easier I moved the configuration to a separate file and added a config for a basic docker setup (using default `resolv-conf`).

Maybe this is interesting for others and worth merging. Pushing the image to docker hub would make things even easier.