### PR TITLE
Convert query to lower case before compare

### DIFF
--- a/server.py
+++ b/server.py
@@ -45,7 +45,7 @@ class BlockNetflixAAAAResolver(object):
             return False
         penultimateDomainPart = parts[-2]
 
-        return query.type == dns.AAAA and penultimateDomainPart in (b'netflix', b'nflximg', b'nflxext', b'nflxvideo', b'nflxso')
+        return query.type == dns.AAAA and penultimateDomainPart.lower() in (b'netflix', b'nflximg', b'nflxext', b'nflxvideo', b'nflxso')
 
     def query(self, query, timeout=None):
         if self.__shouldBlock(query):

--- a/server.py
+++ b/server.py
@@ -2,7 +2,7 @@
 
 OPTIONS = {
     # Port to bind to.
-    'listen-port': 53,
+    'listen-port': 2053,
 
     # Address to bind to.  '::' will bind IPv6; make sure bindv6only is 0 in
     # your sysctl configuration for this binding to service IPv4 clients, too.
@@ -14,7 +14,7 @@ OPTIONS = {
 
     # Specify one or more servers to proxy to.  Note that Twisted may not be
     # happy if you use an IPv6 address.
-    # 'upstream-dns': [('127.0.0.1', 10053)],
+    'upstream-dns': [('1.1.1.1', 53), ('1.0.0.1', 53)],
 
     # Specify a resolv.conf file from which to read upstream nameservers.  As
     # noted above, if you have any upstream IPv6 servers, Twisted may not be

--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 OPTIONS = {
     # Port to bind to.


### PR DESCRIPTION
Queries should be case insensitive. For my use case, an unbound dns forwarder in my home network has the 0x20 [1] feature turned on.

[1] https://tools.ietf.org/html/draft-vixie-dnsext-dns0x20-00